### PR TITLE
Add support for decorating components with custom annotations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ All configuration settings are contained and described in
 | `resources` | CPU and memory limits for corresponding container. | `{}` |
 | `priorityClassName` | The name of the priorityClass for the pods. | Unset |
 | `lifecycle` | controller pod lifecycle hooks | `{}`
-| `core.podAnnotations` | Add custom annotation fields | `{}`
+| `core.controller.podAnnotations` | Add custom annotation fields to the Controller Deployment | `{}`
+| `core.webhook.podAnnotations` | Add custom annotation fields Webhook Deployment | `{}`

--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ All configuration settings are contained and described in
 | `lifecycle` | controller pod lifecycle hooks | `{}`
 | `core.controller.podAnnotations` | Add custom annotation fields to the Controller Deployment | `{}`
 | `core.webhook.podAnnotations` | Add custom annotation fields Webhook Deployment | `{}`
+| `core.autoscaler.podAnnotations` | Add custom annotation fields Webhook Deployment | `{}`

--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ All configuration settings are contained and described in
 | `resources` | CPU and memory limits for corresponding container. | `{}` |
 | `priorityClassName` | The name of the priorityClass for the pods. | Unset |
 | `lifecycle` | controller pod lifecycle hooks | `{}`
+| `core.podAnnotations` | Add custom annotation fields | `{}`

--- a/templates/core/autoscaler/deployment.yaml
+++ b/templates/core/autoscaler/deployment.yaml
@@ -15,8 +15,8 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-{{- if .Values.core.podAnnotations }}
-{{- range $key, $value := .Values.core.podAnnotations }}
+{{- if .Values.core.autoscaler.podAnnotations }}
+{{- range $key, $value := .Values.core.autoscaler.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
 {{- end }}
 {{- end }}

--- a/templates/core/autoscaler/deployment.yaml
+++ b/templates/core/autoscaler/deployment.yaml
@@ -15,6 +15,11 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+{{- if .Values.core.podAnnotations }}
+{{- range $key, $value := .Values.core.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
       labels:
         app: autoscaler
         serving.knative.dev/release: "{{ .Chart.AppVersion }}"

--- a/templates/core/controller/deployment.yaml
+++ b/templates/core/controller/deployment.yaml
@@ -14,8 +14,8 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-{{- if .Values.core.podAnnotations }}
-{{- range $key, $value := .Values.core.podAnnotations }}
+{{- if .Values.core.controller.podAnnotations }}
+{{- range $key, $value := .Values.core.controller.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
 {{- end }}
 {{- end }}

--- a/templates/core/controller/deployment.yaml
+++ b/templates/core/controller/deployment.yaml
@@ -14,6 +14,11 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+{{- if .Values.core.podAnnotations }}
+{{- range $key, $value := .Values.core.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
       labels:
         app: controller
         serving.knative.dev/release: "{{ .Chart.AppVersion }}"

--- a/templates/core/webhook/deployment.yaml
+++ b/templates/core/webhook/deployment.yaml
@@ -14,6 +14,11 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+{{- if .Values.core.webhook.podAnnotations }}
+{{- range $key, $value := .Values.core.webhook.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
       labels:
         app: webhook
         role: webhook

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,7 @@ core:
     priorityClassName: ""
     name: "controller"
     resources: {}
+    podAnnotations: {}
   webhook:
     podDisruptionBudget:
       enabled: true
@@ -37,6 +38,7 @@ core:
     priorityClassName: ""
     name: "webhook"
     resources: {}
+    podAnnotations: {}
   podLabels: {}
   podAnnotations: {}
   tolerations: []

--- a/values.yaml
+++ b/values.yaml
@@ -23,6 +23,7 @@ core:
     replicaCount: 1
     name: "autoscaler"
     resources: {}
+    podAnnotations: {}
   controller:
     podDisruptionBudget:
       enabled: true


### PR DESCRIPTION
I've opened this PR to support adding `core.podAnnotations` value which allows decorating the knative-serving Deployment with custom annotation fields.

Other components of the chart may be allowed to use custom annotations, but I've only accounted for the `Controller`, `Webhook` and `Autoscaler` core components.

Please let me know if I need to update anything else.
